### PR TITLE
feat: Implement user profile page and edit functionality

### DIFF
--- a/client/context/AuthContext.tsx
+++ b/client/context/AuthContext.tsx
@@ -7,6 +7,12 @@ type User = {
   id?: string;
   email?: string;
   phoneNumber?: string;
+  fullName?: string;
+  address?: string;
+  city?: string;
+  state?: string;
+  pincode?: string;
+  profileImageUrl?: string;
   role?: string;
 } | null;
 

--- a/client/pages/Profile.tsx
+++ b/client/pages/Profile.tsx
@@ -54,7 +54,7 @@ export default function Profile() {
   const fetchProfile = async () => {
     try {
       setLoading(true);
-      const res = await fetch("/api/account/profile", {
+      const res = await fetch("/api/accounts/profile", {
         headers: { Authorization: `Bearer ${token}` },
       });
       const data = await res.json().catch(() => ({}));

--- a/client/pages/Profile.tsx
+++ b/client/pages/Profile.tsx
@@ -127,7 +127,9 @@ export default function Profile() {
   if (!isAuthenticated) {
     return (
       <section className="container mx-auto px-4 py-16">
-        <p className="text-muted-foreground">Please log in to view your profile.</p>
+        <p className="text-muted-foreground">
+          Please log in to view your profile.
+        </p>
       </section>
     );
   }
@@ -140,11 +142,12 @@ export default function Profile() {
     );
   }
 
-  const initials = profileData.fullName
-    ?.split(" ")
-    .map((n) => n[0])
-    .join("")
-    .toUpperCase() || "U";
+  const initials =
+    profileData.fullName
+      ?.split(" ")
+      .map((n) => n[0])
+      .join("")
+      .toUpperCase() || "U";
 
   return (
     <section className="container mx-auto px-4 py-8">
@@ -194,7 +197,9 @@ export default function Profile() {
                 <Input
                   id="fullName"
                   value={formData.fullName}
-                  onChange={(e) => handleInputChange("fullName", e.target.value)}
+                  onChange={(e) =>
+                    handleInputChange("fullName", e.target.value)
+                  }
                   disabled={updating}
                   placeholder="Enter your full name"
                 />
@@ -207,7 +212,9 @@ export default function Profile() {
             <div className="grid gap-2">
               <Label htmlFor="email">Email</Label>
               <p className="text-sm py-2">{profileData.email}</p>
-              <p className="text-xs text-muted-foreground">Email cannot be changed</p>
+              <p className="text-xs text-muted-foreground">
+                Email cannot be changed
+              </p>
             </div>
 
             {/* Phone Number */}

--- a/client/pages/Profile.tsx
+++ b/client/pages/Profile.tsx
@@ -95,7 +95,7 @@ export default function Profile() {
   const handleSave = async () => {
     try {
       setUpdating(true);
-      const res = await fetch("/api/account/update-profile", {
+      const res = await fetch("/api/accounts/update-profile", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/server/controllers/accountController.ts
+++ b/server/controllers/accountController.ts
@@ -61,12 +61,10 @@ export const login = async (req: any, res: any) => {
 
     // either require email OR phoneNumber
     if ((!email && !phoneNumber) || !password) {
-      return res
-        .status(400)
-        .json({
-          success: false,
-          message: "Email or PhoneNumber and password are required",
-        });
+      return res.status(400).json({
+        success: false,
+        message: "Email or PhoneNumber and password are required",
+      });
     }
 
     const user = await User.findOne({
@@ -153,8 +151,15 @@ export const updateProfile = async (req: any, res: any) => {
       return res.status(401).json({ success: false, message: "Unauthorized" });
     }
 
-    const { fullName, phoneNumber, address, city, state, pincode, profileImageUrl } =
-      req.body;
+    const {
+      fullName,
+      phoneNumber,
+      address,
+      city,
+      state,
+      pincode,
+      profileImageUrl,
+    } = req.body;
 
     const updateData: any = {};
     if (fullName) updateData.fullName = fullName;

--- a/server/controllers/accountController.ts
+++ b/server/controllers/accountController.ts
@@ -108,6 +108,44 @@ export const login = async (req: any, res: any) => {
   }
 };
 
+export const getProfile = async (req: any, res: any) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ success: false, message: "Unauthorized" });
+    }
+
+    const user = await User.findById(userId).select("-password");
+
+    if (!user) {
+      return res
+        .status(404)
+        .json({ success: false, message: "User not found" });
+    }
+
+    return res.status(200).json({
+      success: true,
+      user: {
+        id: user._id,
+        fullName: user.fullName,
+        email: user.email,
+        phoneNumber: user.phoneNumber,
+        address: user.address || "",
+        city: user.city || "",
+        state: user.state || "",
+        pincode: user.pincode || "",
+        profileImageUrl: user.profileImageUrl || "",
+        role: user.role,
+      },
+    });
+  } catch (error) {
+    console.error("Get profile error:", error);
+    return res
+      .status(500)
+      .json({ success: false, message: "Internal server error" });
+  }
+};
+
 export const updateProfile = async (req: any, res: any) => {
   try {
     const userId = req.user?.id;
@@ -115,20 +153,22 @@ export const updateProfile = async (req: any, res: any) => {
       return res.status(401).json({ success: false, message: "Unauthorized" });
     }
 
-    const { fullName, email, phoneNumber, address, city, state, pincode } =
+    const { fullName, phoneNumber, address, city, state, pincode, profileImageUrl } =
       req.body;
 
     const updateData: any = {};
     if (fullName) updateData.fullName = fullName;
     if (phoneNumber) updateData.phoneNumber = phoneNumber;
-    if (address) updateData.address = address;
-    if (city) updateData.city = city;
-    if (state) updateData.state = state;
-    if (pincode) updateData.pincode = pincode;
+    if (address !== undefined) updateData.address = address;
+    if (city !== undefined) updateData.city = city;
+    if (state !== undefined) updateData.state = state;
+    if (pincode !== undefined) updateData.pincode = pincode;
+    if (profileImageUrl) updateData.profileImageUrl = profileImageUrl;
+    updateData.updated = new Date();
 
     const updatedUser = await User.findByIdAndUpdate(userId, updateData, {
       new: true,
-    });
+    }).select("-password");
 
     if (!updatedUser) {
       return res
@@ -144,6 +184,11 @@ export const updateProfile = async (req: any, res: any) => {
         fullName: updatedUser.fullName,
         email: updatedUser.email,
         phoneNumber: updatedUser.phoneNumber,
+        address: updatedUser.address || "",
+        city: updatedUser.city || "",
+        state: updatedUser.state || "",
+        pincode: updatedUser.pincode || "",
+        profileImageUrl: updatedUser.profileImageUrl || "",
         role: updatedUser.role,
       },
     });

--- a/server/models/userSchema.ts
+++ b/server/models/userSchema.ts
@@ -32,6 +32,7 @@ const userSchema = new mongoose.Schema<IUser>({
 });
 
 // Use existing model if it exists (hot-reload safe)
-const User: Model<IUser> = mongoose.models.User || mongoose.model<IUser>("User", userSchema);
+const User: Model<IUser> =
+  mongoose.models.User || mongoose.model<IUser>("User", userSchema);
 
 export default User;

--- a/server/models/userSchema.ts
+++ b/server/models/userSchema.ts
@@ -7,6 +7,11 @@ interface IUser extends Document {
   phoneNumber: string;
   role: string;
   password: string;
+  address?: string;
+  city?: string;
+  state?: string;
+  pincode?: string;
+  profileImageUrl?: string;
   updated: Date;
   created: Date;
 }
@@ -17,6 +22,11 @@ const userSchema = new mongoose.Schema<IUser>({
   phoneNumber: { type: String, required: true },
   role: { type: String, required: true },
   password: { type: String, required: true },
+  address: { type: String, default: "" },
+  city: { type: String, default: "" },
+  state: { type: String, default: "" },
+  pincode: { type: String, default: "" },
+  profileImageUrl: { type: String, default: "" },
   updated: { type: Date, default: Date.now },
   created: { type: Date, default: Date.now },
 });

--- a/server/routes/accountRouter.ts
+++ b/server/routes/accountRouter.ts
@@ -1,11 +1,12 @@
 import express from "express";
-import { login, signup, updateProfile } from "../controllers/accountController";
+import { login, signup, updateProfile, getProfile } from "../controllers/accountController";
 import { authVerify } from "../middleware/authVerify";
 
 const accountsRoutes = express.Router();
 
 accountsRoutes.post("/signup", signup);
 accountsRoutes.post("/login", login);
+accountsRoutes.get("/profile", authVerify, getProfile);
 accountsRoutes.post("/update-profile", authVerify, updateProfile);
 
 export default accountsRoutes;

--- a/server/routes/accountRouter.ts
+++ b/server/routes/accountRouter.ts
@@ -1,5 +1,10 @@
 import express from "express";
-import { login, signup, updateProfile, getProfile } from "../controllers/accountController";
+import {
+  login,
+  signup,
+  updateProfile,
+  getProfile,
+} from "../controllers/accountController";
 import { authVerify } from "../middleware/authVerify";
 
 const accountsRoutes = express.Router();


### PR DESCRIPTION
### Purpose

The user requested to add a user profile section where users can view and edit their personal information. This includes their full name, address (address, city, state, pincode), and profile picture.

### Code changes

*   **Backend**:
    *   Extended the `userSchema` in MongoDB to include fields for `address`, `city`, `state`, `pincode`, and `profileImageUrl`.
    *   Added a new API endpoint `GET /api/accounts/profile` to fetch the logged-in user's profile data.
    *   Modified the `POST /api/accounts/update-profile` endpoint to support updating the new fields and handling profile image uploads.

*   **Frontend**:
    *   Overhauled the `Profile.tsx` page to fetch user data from the new backend endpoint.
    *   Implemented a user interface for displaying the profile information, including an avatar for the profile picture.
    *   Created an "edit mode" that allows users to modify their details and upload a new profile image.
    *   Updated the `AuthContext` to reflect profile changes, ensuring the UI is consistent across the application after an update.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/8d407c866d6347ecbba49f0492e02760/pulse-verse)

👀 [Preview Link](https://8d407c866d6347ecbba49f0492e02760-pulse-verse.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8d407c866d6347ecbba49f0492e02760</projectId>-->
<!--<branchName>pulse-verse</branchName>-->