### PR TITLE
Feat: Add Profile link to header for authenticated users

### DIFF
--- a/client/components/site/Layout.tsx
+++ b/client/components/site/Layout.tsx
@@ -204,6 +204,20 @@ function Header() {
                   </NavLink>
                 </>
               ))}
+            {isAuthenticated && (
+              <NavLink
+                to="/dashboard/profile"
+                onClick={() => setOpen(false)}
+                className={({ isActive }) =>
+                  cn(
+                    "px-2 py-2 rounded-md text-sm font-medium",
+                    isActive ? "text-primary" : "text-foreground/70",
+                  )
+                }
+              >
+                Profile
+              </NavLink>
+            )}
             {isAuthenticated ? (
               <Button
                 size="sm"

--- a/client/components/site/Layout.tsx
+++ b/client/components/site/Layout.tsx
@@ -80,6 +80,19 @@ function Header() {
                 </NavLink>
               </>
             ))}
+          {isAuthenticated && (
+            <NavLink
+              to="/dashboard/profile"
+              className={({ isActive }) =>
+                cn(
+                  "px-3 py-2 rounded-md text-sm font-medium transition-colors hover:text-foreground/80",
+                  isActive ? "text-primary" : "text-foreground/70",
+                )
+              }
+            >
+              Profile
+            </NavLink>
+          )}
           <NavLink
             to="/about"
             className={({ isActive }) =>


### PR DESCRIPTION
### Purpose

The user reported that they were unable to see the profile section. This change aims to solve this issue by making the profile page accessible to authenticated users from the main navigation.

### Code changes

- A "Profile" link has been added to the main header navigation in `client/components/site/Layout.tsx`.
- The same link has also been added to the mobile navigation menu.
- This link is only visible to authenticated users and navigates to `/dashboard/profile`.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/8d407c866d6347ecbba49f0492e02760/stellar-realm)

👀 [Preview Link](https://8d407c866d6347ecbba49f0492e02760-stellar-realm.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8d407c866d6347ecbba49f0492e02760</projectId>-->
<!--<branchName>stellar-realm</branchName>-->