### PR TITLE
Fix: Handle undefined properties in Complaint filter

### DIFF
--- a/client/pages/Complaint.tsx
+++ b/client/pages/Complaint.tsx
@@ -112,11 +112,11 @@ export default function Complaint() {
 
   const filteredComplaints = complaints.filter((c) => {
     const matchesSearch =
-      c.complaintDetail.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      c.firstName.toLowerCase().includes(searchTerm.toLowerCase());
+      (c.complaintDetail ?? "").toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (c.firstName ?? "").toLowerCase().includes(searchTerm.toLowerCase());
     const matchesStatus =
       statusFilter === "All Status" ||
-      c.complaintStatus.toLowerCase() === statusFilter.toLowerCase();
+      (c.complaintStatus ?? "").toLowerCase() === statusFilter.toLowerCase();
     return matchesSearch && matchesStatus;
   });
 

--- a/client/pages/Complaint.tsx
+++ b/client/pages/Complaint.tsx
@@ -293,20 +293,20 @@ export default function Complaint() {
               {filteredComplaints.map((c) => (
                 <tr key={c._id} className="border-b hover:bg-muted/30">
                   <td className="py-3 px-4 text-primary font-semibold">
-                    {c._id.slice(0, 8)}
+                    {(c._id ?? "").slice(0, 8)}
                   </td>
                   <td className="py-3 px-4 text-primary max-w-xs">
-                    {c.complaintDetail.slice(0, 40)}
+                    {(c.complaintDetail ?? "").slice(0, 40)}
                   </td>
                   <td className="py-3 px-4">
                     <span className="px-2 py-1 rounded-full text-xs bg-secondary">
-                      {c.complaintStatus}
+                      {c.complaintStatus ?? "-"}
                     </span>
                   </td>
                   <td className="py-3 px-4 text-xs text-muted-foreground">-</td>
                   {isAdmin && (
                     <td className="py-3 px-4 text-sm">
-                      {c.firstName} {c.lastName}
+                      {(c.firstName ?? "")} {(c.lastName ?? "")}
                     </td>
                   )}
                   <td className="py-3 px-4 text-xs">

--- a/client/pages/Complaint.tsx
+++ b/client/pages/Complaint.tsx
@@ -112,7 +112,9 @@ export default function Complaint() {
 
   const filteredComplaints = complaints.filter((c) => {
     const matchesSearch =
-      (c.complaintDetail ?? "").toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (c.complaintDetail ?? "")
+        .toLowerCase()
+        .includes(searchTerm.toLowerCase()) ||
       (c.firstName ?? "").toLowerCase().includes(searchTerm.toLowerCase());
     const matchesStatus =
       statusFilter === "All Status" ||

--- a/client/pages/Complaint.tsx
+++ b/client/pages/Complaint.tsx
@@ -29,12 +29,12 @@ type FormData = z.infer<typeof schema>;
 
 interface ComplaintItem {
   _id: string;
-  firstName: string;
-  lastName: string;
-  email: string;
-  phoneNumber: string;
-  complaintDetail: string;
-  complaintStatus: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phoneNumber?: string;
+  complaintDetail?: string;
+  complaintStatus?: string;
   created: string;
   resolution?: { response?: string } | null;
 }

--- a/client/pages/Complaint.tsx
+++ b/client/pages/Complaint.tsx
@@ -306,7 +306,7 @@ export default function Complaint() {
                   <td className="py-3 px-4 text-xs text-muted-foreground">-</td>
                   {isAdmin && (
                     <td className="py-3 px-4 text-sm">
-                      {(c.firstName ?? "")} {(c.lastName ?? "")}
+                      {c.firstName ?? ""} {c.lastName ?? ""}
                     </td>
                   )}
                   <td className="py-3 px-4 text-xs">


### PR DESCRIPTION
### Purpose

The user was encountering a `TypeError` in the `Complaint` component, which was caused by an attempt to call `toLowerCase()` on an `undefined` value. This happened when filtering complaints, as some complaint items were missing properties that were expected to be strings. The goal of this change is to prevent this runtime error and make the filtering logic more robust.

### Code changes

- The `ComplaintItem` interface has been updated to make the `firstName`, `lastName`, `email`, `phoneNumber`, `complaintDetail`, and `complaintStatus` properties optional.
- Nullish coalescing (`?? ""`) has been added to the filtering logic in `Complaint.tsx`. This ensures that if `complaintDetail`, `firstName`, or `complaintStatus` are `null` or `undefined`, they are treated as empty strings before `toLowerCase()` is called, thus preventing the crash.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/8d407c866d6347ecbba49f0492e02760/curry-verse)

👀 [Preview Link](https://8d407c866d6347ecbba49f0492e02760-curry-verse.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8d407c866d6347ecbba49f0492e02760</projectId>-->
<!--<branchName>curry-verse</branchName>-->